### PR TITLE
Main

### DIFF
--- a/src/bin/test_command_builder.rs
+++ b/src/bin/test_command_builder.rs
@@ -8,7 +8,9 @@ fn main() {
         manifest_path: "Cargo.toml".to_string(),
         kind: TargetKind::Example,
         extended: true,
-        origin: Some(TargetOrigin::SingleFile(PathBuf::from("examples/my_example.rs"))),
+        origin: Some(TargetOrigin::SingleFile(PathBuf::from(
+            "examples/my_example.rs",
+        ))),
     };
 
     let args = CargoCommandBuilder::new()
@@ -18,4 +20,3 @@ fn main() {
 
     println!("Built Cargo command: {:?}", args);
 }
-

--- a/src/e_command_builder.rs
+++ b/src/e_command_builder.rs
@@ -121,7 +121,9 @@ mod tests {
             manifest_path: "Cargo.toml".to_string(),
             kind: TargetKind::Example,
             extended: true,
-            origin: Some(TargetOrigin::SingleFile(PathBuf::from("examples/my_example.rs"))),
+            origin: Some(TargetOrigin::SingleFile(PathBuf::from(
+                "examples/my_example.rs",
+            ))),
         };
 
         let extra_args = vec!["--flag".to_string(), "value".to_string()];
@@ -143,4 +145,3 @@ mod tests {
         assert!(args.contains(&"value".to_string()));
     }
 }
-

--- a/src/e_discovery.rs
+++ b/src/e_discovery.rs
@@ -1,8 +1,5 @@
 // src/e_discovery.rs
-use std::{
-    fs,
-    path::Path,
-};
+use std::{fs, path::Path};
 
 use crate::e_target::{CargoTarget, TargetKind, TargetOrigin};
 use anyhow::{Context, Result};
@@ -41,7 +38,8 @@ pub fn discover_targets(current_dir: &Path) -> Result<Vec<CargoTarget>> {
                             targets.push(CargoTarget {
                                 name: stem.to_string_lossy().to_string(),
                                 display_name: stem.to_string_lossy().to_string(),
-                                manifest_path: current_dir.join("Cargo.toml")
+                                manifest_path: current_dir
+                                    .join("Cargo.toml")
                                     .to_string_lossy()
                                     .to_string(),
                                 kind: TargetKind::Example,
@@ -112,4 +110,3 @@ mod tests {
         assert!(example_target.is_some());
     }
 }
-

--- a/src/e_target.rs
+++ b/src/e_target.rs
@@ -1,8 +1,5 @@
 // src/e_target.rs
-use std::{
-    ffi::OsString,
-    path::PathBuf,
-};
+use std::{ffi::OsString, path::PathBuf};
 
 #[derive(Debug, Clone)]
 pub enum TargetOrigin {
@@ -12,7 +9,7 @@ pub enum TargetOrigin {
     Named(OsString),
 }
 
-#[derive(Debug, Clone,PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TargetKind {
     Example,
     Binary,
@@ -29,4 +26,3 @@ pub struct CargoTarget {
     pub extended: bool,
     pub origin: Option<TargetOrigin>,
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,9 +32,8 @@ pub use e_parser::parse_available;
 pub mod e_runner;
 pub use e_runner::run_example;
 pub mod e_collect;
-pub mod e_features;
-pub mod e_tui;
 pub mod e_command_builder;
-pub mod e_target;
 pub mod e_discovery;
-
+pub mod e_features;
+pub mod e_target;
+pub mod e_tui;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,5 @@
 // tests/common/mod.rs
 
 pub mod test_prelude;
+pub mod test_testgen;
 pub mod test_utils;
-pub mod test_existing;

--- a/tests/common/test_prelude.rs
+++ b/tests/common/test_prelude.rs
@@ -1,8 +1,1 @@
 // common/test_prelude.rs
-
-// Re-export commonly used items for integration tests.
-pub use assert_cmd::Command;
-pub use predicates::prelude::*;
-pub use predicates::str::contains;
-
-//pub use super::test_utils::*;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,7 +2,7 @@
 mod common;
 
 // use common::test_prelude::*;
-use common::test_existing::project_setup::{create_testgen_ex_project, create_testgen_bin_project};
+use common::test_testgen::project_setup::{create_testgen_bin_project, create_testgen_ex_project};
 
 #[test]
 fn test_example_project() {
@@ -10,7 +10,7 @@ fn test_example_project() {
     // Use assert_cmd or other prelude items from test_prelude
     assert!(project.path().join("Cargo.toml").exists());
 }
- 
+
 #[test]
 fn test_create_testgen_bin_project() -> std::io::Result<()> {
     // Use a known binary name for testing.
@@ -27,9 +27,15 @@ fn test_create_testgen_bin_project() -> std::io::Result<()> {
     assert!(bin_file.exists(), "The binary file should exist");
 
     // Read the file and verify its contents.
-    let contents =std::fs::read_to_string(&bin_file)?;
-    let expected = format!("fn main() {{ println!(\"{} HAS RUN SUCCESSFULLY\"); }}", bin_name);
-    assert_eq!(contents, expected, "The file content should match the expected output");
+    let contents = std::fs::read_to_string(&bin_file)?;
+    let expected = format!(
+        "fn main() {{ println!(\"{} HAS RUN SUCCESSFULLY\"); }}",
+        bin_name
+    );
+    assert_eq!(
+        contents, expected,
+        "The file content should match the expected output"
+    );
 
     Ok(())
 }

--- a/tests/test_command_builder.rs
+++ b/tests/test_command_builder.rs
@@ -9,7 +9,9 @@ fn integration_test_builder() {
         manifest_path: "Cargo.toml".to_string(),
         kind: TargetKind::Example,
         extended: true,
-        origin: Some(TargetOrigin::SingleFile(PathBuf::from("examples/my_example.rs"))),
+        origin: Some(TargetOrigin::SingleFile(PathBuf::from(
+            "examples/my_example.rs",
+        ))),
     };
 
     let args = CargoCommandBuilder::new()
@@ -19,4 +21,3 @@ fn integration_test_builder() {
 
     assert!(args.contains(&"run".to_string()));
 }
-

--- a/tests/test_version_feature_flags.rs
+++ b/tests/test_version_feature_flags.rs
@@ -1,8 +1,7 @@
-mod common {
-    pub mod test_prelude;
-}
+use assert_cmd::Command;
 use cargo_e::e_features::{get_feature_flags, get_feature_flags_json};
-use common::test_prelude::*;
+use predicates::prelude::*;
+use predicates::str::contains;
 
 #[test]
 fn test_version_feature_flags() {


### PR DESCRIPTION
refactor: reformat command builder usage and update test module structure

- In src/bin/test_command_builder.rs and src/e_command_builder.rs, reformat the use of PathBuf::from("examples/my_example.rs") by splitting the string literal over multiple lines for improved readability.
- In src/e_discovery.rs, simplify join expressions for constructing manifest paths.
- Adjust spacing in src/e_target.rs for consistent formatting.
- Reorder module exports in src/lib.rs to group new modules (e_features, e_target, e_tui) together.
- Rename tests/common/test_existing.rs to tests/common/test_testgen.rs and update integration tests to import from test_testgen.
- In tests/test_version_feature_flags.rs, remove the redundant local mod common block and directly import assert_cmd::Command and predicates::str::contains.
