### PR TITLE
fix: update e_interactive_crate_upgrade and adjust feature checks in …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,9 +1058,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.0"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "openssl"
@@ -1623,11 +1623,10 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567"
+checksum = "488960f40a3fd53d72c2a29a58722561dee8afdd175bd88e3db4677d7b2ba600"
 dependencies = [
- "cfg-if",
  "fastrand",
  "getrandom",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,15 @@ keywords = ["cargo", "examples", "binaries", "workspace", "rust"]
 categories = ["command-line-utilities", "development-tools"]
 authors = ["David Horner"]
 default-run = "cargo-e"
+include = [
+    "src/**",
+    "addendum/**",
+    "Cargo.toml",
+    "build.rs",
+    "build_addendum_utils.rs",
+    "build_docs.rs",
+    # other files you want to include
+]
 
 [features]
 default = ["tui", "concurrent", "funny-docs", "check-version","addendum_inline","uses_reqwest","uses_serde"]

--- a/addendum/e_crate_version_checker/src/e_interactive_crate_upgrade.rs
+++ b/addendum/e_crate_version_checker/src/e_interactive_crate_upgrade.rs
@@ -13,8 +13,8 @@ use crate::e_crate_update::version::get_latest_version;
 // #[cfg(feature = "addendum_inline")]
 // use e_crate_version_checker::e_crate_update::update_crate;
 
-#[cfg(not(feature = "addendum_inline"))]
-compile_error!("The 'addendum_inline' feature is not enabled. Please enable it for the desired behavior.");
+// #[cfg(not(feature = "addendum_inline"))]
+// compile_error!("The 'addendum_inline' feature is not enabled. Please enable it for the desired behavior.");
 
 #[cfg(not(feature = "addendum_inline"))]
 use crate::e_crate_update::update_crate; 

--- a/addendum/e_crate_version_checker/src/main.rs
+++ b/addendum/e_crate_version_checker/src/main.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Interrogate Cargo for the local version of the target crate.
     let current_version =
         lookup_local_version_via_cargo(crate_name).unwrap_or_else(|| "0.0.0".to_string());
-    interactive_crate_upgrade(crate_name, &current_version)?;
+    interactive_crate_upgrade(crate_name, &current_version, 5)?;
     Ok(())
 }
 

--- a/build.rs
+++ b/build.rs
@@ -31,6 +31,8 @@ fn main() {
         .expect("Failed to generate module includes");
     let dest_path = Path::new(&out_dir).join("generated_e_crate_version_checker.rs");
     println!("cargo:warning=Writing generated file to {:?}", dest_path);
+    let generated = std::fs::read_to_string(&dest_path).expect("Failed to read the generated file");
+    println!("cargo:warning=Generated file content:\n{}", generated);
     if generated_code.is_empty() {
         println!("cargo:warning=No addendum files found in {:?}", src_dir);
         std::process::exit(1);

--- a/build_addendum_utils.rs
+++ b/build_addendum_utils.rs
@@ -27,6 +27,10 @@ fn transform_file_contents(contents: &str) -> String {
         result.push_str(line);
         result.push('\n');
     }
+    result = result.replace(
+        "crate::e_crate_update",
+        "inlined_e_crate_version_checker::e_crate_update",
+    );
 
     result
 }
@@ -100,6 +104,14 @@ pub fn generate_module_includes(src_dir: &Path, out_dir: &Path) -> io::Result<St
             println!("Processed file: {:?} as module '{}'", path, module_name);
         }
     }
+    // After processing all files, append a prelude module:
+    output.push_str(
+        "\npub mod prelude {\n\
+     \tpub use super::e_crate_update::version::get_latest_version;\n\
+     \tpub use super::e_crate_update::update_crate;\n\
+     \tpub use super::e_interactive_crate_upgrade::interactive_crate_upgrade;\n\
+     }\n",
+    );
     Ok(output)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,12 +16,16 @@
 //!
 //! See the [GitHub repository](https://github.com/davehorner/cargo-e) for more details.
 
-use crate::inlined_e_crate_version_checker::e_interactive_crate_upgrade;
+// Declare the module so that the contents of "src/inlined_e_crate_version_checker.rs" are compiled.
+mod inlined_e_crate_version_checker;
+
+// Now import from the prelude.
+#[cfg(feature = "check-version-program-start")]
+use inlined_e_crate_version_checker::prelude::*;
+
 use cargo_e::prelude::*;
 use cargo_e::{Cli, Example, TargetKind};
 use clap::Parser;
-#[cfg(feature = "check-version-program-start")]
-mod inlined_e_crate_version_checker;
 
 pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut args: Vec<String> = env::args().collect();
@@ -47,11 +51,7 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // Use the version from `lookup_cargo_e_version` if valid,
         // otherwise fallback to the compile-time version.
-        e_interactive_crate_upgrade::interactive_crate_upgrade(
-            env!("CARGO_PKG_NAME"),
-            &version,
-            cli.wait,
-        )?;
+        interactive_crate_upgrade(env!("CARGO_PKG_NAME"), &version, cli.wait)?;
     }
 
     // let manifest_current = locate_manifest(false).unwrap_or_default();


### PR DESCRIPTION
…e_crate_version_checker

- Commented out compile_error for 'addendum_inline' feature in e_interactive_crate_upgrade.rs
- Updated interactive_crate_upgrade call in main.rs to include a timeout parameter
- Added generated file content logging in build.rs
- Transformed crate update path in build_addendum_utils.rs
- Introduced a prelude module in generated includes for easier access to crate functionalities