### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cargo-e"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -404,7 +404,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "e_crate_version_checker"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "reqwest",
  "serde",

--- a/addendum/e_crate_version_checker/CHANGELOG.md
+++ b/addendum/e_crate_version_checker/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 
 
+## [0.1.6](https://github.com/davehorner/cargo-e/compare/e_crate_version_checker-v0.1.5...e_crate_version_checker-v0.1.6) - 2025-03-16
+
+### Added
+
+- *(cli, ctrlc, run-history)* add once_cell, global Ctrl+C handler & interactive paging
+
 ## [0.1.5](https://github.com/davehorner/cargo-e/compare/e_crate_version_checker-v0.1.4...e_crate_version_checker-v0.1.5) - 2025-03-15
 
 ### Added

--- a/addendum/e_crate_version_checker/Cargo.toml
+++ b/addendum/e_crate_version_checker/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e_crate_version_checker"
 description = "A tool to check for newer versions of Rust crates on crates.io and interactively update them."
 license = "MIT OR Apache-2.0"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["David Horner"]
 edition = "2021"
 publish = true

--- a/cargo-e/CHANGELOG.md
+++ b/cargo-e/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14](https://github.com/davehorner/cargo-e/compare/cargo-e-v0.1.13...cargo-e-v0.1.14) - 2025-03-16
+
+### Other
+
+- updated the following local packages: e_crate_version_checker
+
 ## [0.1.13](https://github.com/davehorner/cargo-e/compare/cargo-e-v0.1.12...cargo-e-v0.1.13) - 2025-03-16
 
 ### Added

--- a/cargo-e/Cargo.toml
+++ b/cargo-e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-e"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 description = "e is for Example. A command-line tool for running and exploring source, examples, and binaries from Rust projects. It will run the first example, if no options are given."
 license = "MIT OR Apache-2.0"
@@ -83,7 +83,7 @@ path = "src/main.rs"
 # features = ["uses_reqwest", "uses_serde"]
 
 [dependencies]
-e_crate_version_checker = { path = "../addendum/e_crate_version_checker", version = "0.1.5" }
+e_crate_version_checker = { path = "../addendum/e_crate_version_checker", version = "0.1.6" }
 anyhow = "1.0.97"
 clap = { version = "4.5.31", features = ["derive"] }
 crossterm = { version = "0.28.1", optional = true }


### PR DESCRIPTION



## 🤖 New release

* `e_crate_version_checker`: 0.1.5 -> 0.1.6 (✓ API compatible changes)
* `cargo-e`: 0.1.13 -> 0.1.14

<details><summary><i><b>Changelog</b></i></summary><p>

## `e_crate_version_checker`

<blockquote>

## [0.1.6](https://github.com/davehorner/cargo-e/compare/e_crate_version_checker-v0.1.5...e_crate_version_checker-v0.1.6) - 2025-03-16

### Added

- *(cli, ctrlc, run-history)* add once_cell, global Ctrl+C handler & interactive paging
</blockquote>

## `cargo-e`

<blockquote>

## [0.1.14](https://github.com/davehorner/cargo-e/compare/cargo-e-v0.1.13...cargo-e-v0.1.14) - 2025-03-16

### Other

- updated the following local packages: e_crate_version_checker
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).