### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-e"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1729,7 +1729,7 @@ dependencies = [
 
 [[package]]
 name = "e_crate_version_checker"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "genai",
  "parse-changelog",

--- a/addendum/e_crate_version_checker/CHANGELOG.md
+++ b/addendum/e_crate_version_checker/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.26](https://github.com/davehorner/cargo-e/compare/e_crate_version_checker-v0.1.25...e_crate_version_checker-v0.1.26) - 2025-05-31
+
+### Added
+
+- *(e-window,failed_build_window)* Implement anchor links in e_window for launching code on error lines.  Failed builds now include a graphical window which includes just the errors.
+
 ## [0.1.25](https://github.com/davehorner/cargo-e/compare/e_crate_version_checker-v0.1.24...e_crate_version_checker-v0.1.25) - 2025-05-29
 
 ### Other

--- a/addendum/e_crate_version_checker/Cargo.toml
+++ b/addendum/e_crate_version_checker/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e_crate_version_checker"
 description = "A tool to check for newer versions of Rust crates on crates.io and interactively update them."
 license = "MIT OR Apache-2.0"
-version = "0.1.25"
+version = "0.1.26"
 authors = ["David Horner"]
 edition = "2021"
 rust-version = "1.81.0"

--- a/cargo-e/CHANGELOG.md
+++ b/cargo-e/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.34](https://github.com/davehorner/cargo-e/compare/cargo-e-v0.2.33...cargo-e-v0.2.34) - 2025-05-31
+
+### Other
+
+- updated the following local packages: e_crate_version_checker
+
 ## [0.2.33](https://github.com/davehorner/cargo-e/compare/cargo-e-v0.2.32...cargo-e-v0.2.33) - 2025-05-31
 
 ### Added

--- a/cargo-e/Cargo.toml
+++ b/cargo-e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-e"
-version = "0.2.33"
+version = "0.2.34"
 edition = "2021"
 rust-version = "1.85.1"
 description = "e is for Example. A command-line tool for running and exploring source, examples, and binaries from Rust projects. It will run the first example, if no options are given."
@@ -78,7 +78,7 @@ name = "cargo-e"
 path = "src/main.rs"
 
 [dependencies]
-e_crate_version_checker = { path = "../addendum/e_crate_version_checker", version = "0.1.25", optional = true }
+e_crate_version_checker = { path = "../addendum/e_crate_version_checker", version = "0.1.26", optional = true }
 e_ai_summarize = { path = "../addendum/e_ai_summarize", version = "0.1.13", optional = true }
 anyhow = "1.0.97"
 clap = { version = "4.5.31", features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `e_crate_version_checker`: 0.1.25 -> 0.1.26 (✓ API compatible changes)
* `cargo-e`: 0.2.33 -> 0.2.34

<details><summary><i><b>Changelog</b></i></summary><p>

## `e_crate_version_checker`

<blockquote>

## [0.1.26](https://github.com/davehorner/cargo-e/compare/e_crate_version_checker-v0.1.25...e_crate_version_checker-v0.1.26) - 2025-05-31

### Added

- *(e-window,failed_build_window)* Implement anchor links in e_window for launching code on error lines.  Failed builds now include a graphical window which includes just the errors.
</blockquote>

## `cargo-e`

<blockquote>

## [0.2.34](https://github.com/davehorner/cargo-e/compare/cargo-e-v0.2.33...cargo-e-v0.2.34) - 2025-05-31

### Other

- updated the following local packages: e_crate_version_checker
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).