### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-e"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1773,7 +1773,7 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "e_ai_summarize"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "arboard",
@@ -1796,7 +1796,7 @@ dependencies = [
 
 [[package]]
 name = "e_crate_version_checker"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "genai",
  "parse-changelog",
@@ -1833,7 +1833,7 @@ dependencies = [
 
 [[package]]
 name = "e_window"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chrono",
  "eframe",

--- a/addendum/e_ai_summarize/CHANGELOG.md
+++ b/addendum/e_ai_summarize/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15](https://github.com/davehorner/cargo-e/compare/e_ai_summarize-v0.1.14...e_ai_summarize-v0.1.15) - 2025-06-06
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.14](https://github.com/davehorner/cargo-e/compare/e_ai_summarize-v0.1.13...e_ai_summarize-v0.1.14) - 2025-06-01
 
 ### Other

--- a/addendum/e_ai_summarize/Cargo.toml
+++ b/addendum/e_ai_summarize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "e_ai_summarize"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 rust-version = "1.85.1"
 authors = ["David Horner"]

--- a/addendum/e_crate_version_checker/CHANGELOG.md
+++ b/addendum/e_crate_version_checker/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.27](https://github.com/davehorner/cargo-e/compare/e_crate_version_checker-v0.1.26...e_crate_version_checker-v0.1.27) - 2025-06-06
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.26](https://github.com/davehorner/cargo-e/compare/e_crate_version_checker-v0.1.25...e_crate_version_checker-v0.1.26) - 2025-06-01
 
 ### Added

--- a/addendum/e_crate_version_checker/Cargo.toml
+++ b/addendum/e_crate_version_checker/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e_crate_version_checker"
 description = "A tool to check for newer versions of Rust crates on crates.io and interactively update them."
 license = "MIT OR Apache-2.0"
-version = "0.1.26"
+version = "0.1.27"
 authors = ["David Horner"]
 edition = "2021"
 rust-version = "1.81.0"

--- a/addendum/e_window/CHANGELOG.md
+++ b/addendum/e_window/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/davehorner/cargo-e/compare/e_window-v0.1.3...e_window-v0.1.4) - 2025-06-06
+
+### Added
+
+- add e_obs script for OBS control and recording functionality https://www.youtube.com/watch?v=5BXStX87Z0o
+
 ## [0.1.3](https://github.com/davehorner/cargo-e/compare/e_window-v0.1.2...e_window-v0.1.3) - 2025-06-01
 
 ### Other

--- a/addendum/e_window/Cargo.toml
+++ b/addendum/e_window/Cargo.toml
@@ -3,7 +3,7 @@ edition = "2021"
 name = "e_window"
 description = "A window tool. Think WinAPI ShowMessageBox; but more than that."
 license = "MIT"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["David Horner"]
 publish = true
 

--- a/cargo-e/CHANGELOG.md
+++ b/cargo-e/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.38](https://github.com/davehorner/cargo-e/compare/cargo-e-v0.2.37...cargo-e-v0.2.38) - 2025-06-06
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.2.37](https://github.com/davehorner/cargo-e/compare/cargo-e-v0.2.36...cargo-e-v0.2.37) - 2025-06-03
 
 ### Added

--- a/cargo-e/Cargo.toml
+++ b/cargo-e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-e"
-version = "0.2.37"
+version = "0.2.38"
 edition = "2021"
 rust-version = "1.85.1"
 description = "e is for Example. A command-line tool for running and exploring source, examples, and binaries from Rust projects. It will run the first example, if no options are given."
@@ -92,8 +92,8 @@ name = "cargo-e"
 path = "src/main.rs"
 
 [dependencies]
-e_crate_version_checker = { path = "../addendum/e_crate_version_checker", version = "0.1.26", optional = true }
-e_ai_summarize = { path = "../addendum/e_ai_summarize", version = "0.1.14", optional = true }
+e_crate_version_checker = { path = "../addendum/e_crate_version_checker", version = "0.1.27", optional = true }
+e_ai_summarize = { path = "../addendum/e_ai_summarize", version = "0.1.15", optional = true }
 anyhow = "1.0.97"
 clap = { version = "4.5.31", features = ["derive"] }
 crossterm = { version = "0.29.0", optional = true }


### PR DESCRIPTION



## 🤖 New release

* `e_ai_summarize`: 0.1.14 -> 0.1.15 (✓ API compatible changes)
* `e_crate_version_checker`: 0.1.26 -> 0.1.27 (✓ API compatible changes)
* `cargo-e`: 0.2.37 -> 0.2.38 (✓ API compatible changes)
* `e_window`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `e_obs`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `e_ai_summarize`

<blockquote>

## [0.1.15](https://github.com/davehorner/cargo-e/compare/e_ai_summarize-v0.1.14...e_ai_summarize-v0.1.15) - 2025-06-06

### Other

- update Cargo.lock dependencies
</blockquote>

## `e_crate_version_checker`

<blockquote>

## [0.1.27](https://github.com/davehorner/cargo-e/compare/e_crate_version_checker-v0.1.26...e_crate_version_checker-v0.1.27) - 2025-06-06

### Other

- update Cargo.lock dependencies
</blockquote>

## `cargo-e`

<blockquote>

## [0.2.38](https://github.com/davehorner/cargo-e/compare/cargo-e-v0.2.37...cargo-e-v0.2.38) - 2025-06-06

### Other

- update Cargo.lock dependencies
</blockquote>

## `e_window`

<blockquote>

## [0.1.4](https://github.com/davehorner/cargo-e/compare/e_window-v0.1.3...e_window-v0.1.4) - 2025-06-06

### Added

- add e_obs script for OBS control and recording functionality https://www.youtube.com/watch?v=5BXStX87Z0o
</blockquote>

## `e_obs`

<blockquote>

## [0.1.0](https://github.com/davehorner/cargo-e/releases/tag/e_obs-v0.1.0) - 2025-06-05

### Added

- add e_obs script for OBS control and recording functionality https://www.youtube.com/watch?v=5BXStX87Z0o
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).